### PR TITLE
feat: set image values for all deployments in knative eventing

### DIFF
--- a/charts/knative-eventing/Chart.yaml
+++ b/charts/knative-eventing/Chart.yaml
@@ -21,4 +21,4 @@ name: knative-eventing
 sources:
   - https://github.com/Ahhhh-man/charts/tree/main/charts/knative-eventing
 type: application
-version: 0.2.2
+version: 0.2.3

--- a/charts/knative-eventing/templates/_helpers.tpl
+++ b/charts/knative-eventing/templates/_helpers.tpl
@@ -6,6 +6,47 @@ license that can be found in the LICENSE file.
 
 {{/* vim: set filetype=mustache: */}}
 
+{{/*
+Return the proper image name.
+If image tag and digest are not defined, termination fallbacks to chart appVersion.
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global "chart" .Chart ) }}
+*/}}
+{{- define "common.images.image" -}}
+{{- $registryName := default .imageRoot.registry ((.global).imageRegistry) -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
+
+{{- if not .imageRoot.tag }}
+  {{- if .chart }}
+    {{- $termination = .chart.AppVersion | toString -}}
+  {{- end -}}
+{{- end -}}
+{{- if .imageRoot.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
+{{- end -}}
+{{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "knative-eventing.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "knative-eventing.name" -}}
+{{- default "knative-eventing" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Define the version defined by AppVersion 
@@ -13,3 +54,65 @@ Define the version defined by AppVersion
 {{- define "knative-eventing.version" -}}
 {{- default .Chart.AppVersion | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "knative-eventing.labels" -}}
+helm.sh/chart: {{ include "knative-eventing.chart" . }}
+app.kubernetes.io/name: {{ include "knative-eventing.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "knative-eventing.selectorLabels" . }}
+{{- if or .Chart.AppVersion .Values.image.tag }}
+app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
+{{- end }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common annotations
+*/}}
+{{- define "knative-eventing.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "knative-eventing.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "knative-eventing.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Return the proper controller image name
+*/}}
+{{- define "knative-eventing.controller.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the proper jobsink image name
+*/}}
+{{- define "knative-eventing.jobsink.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.jobsink.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the proper Pingsource MT Adapter image name
+*/}}
+{{- define "knative-eventing.mtping.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.mtping.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the proper Webhook image name
+*/}}
+{{- define "knative-eventing.webhook.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.webhook.image "global" .Values.global) -}}
+{{- end -}}

--- a/charts/knative-eventing/templates/core/configmaps/default-broker-channel.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/default-broker-channel.yaml
@@ -16,10 +16,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-br-default-channel
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 data:
   channel-template-spec: |
     apiVersion: messaging.knative.dev/v1

--- a/charts/knative-eventing/templates/core/configmaps/default-broker.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/default-broker.yaml
@@ -16,10 +16,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-br-defaults
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 data:
   # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |

--- a/charts/knative-eventing/templates/core/configmaps/default-channel.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/default-channel.yaml
@@ -16,10 +16,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-ch-webhook
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-ch-config: |

--- a/charts/knative-eventing/templates/core/configmaps/default-pingsource.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/default-pingsource.yaml
@@ -16,9 +16,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-ping-defaults
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "knative-eventing.labels" . | nindent 4 }}
   annotations:
-    knative.dev/example-checksum: "9185c153"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 data:

--- a/charts/knative-eventing/templates/core/configmaps/features.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/features.yaml
@@ -16,12 +16,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-features
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 data:
 {{- range $key, $value := .Values.config.features }}
   {{ $key }}: {{ $value | toYaml | indent 4 | trim }}

--- a/charts/knative-eventing/templates/core/configmaps/kreference-mapping.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/kreference-mapping.yaml
@@ -16,11 +16,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-kreference-mapping
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
   annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
     knative.dev/example-checksum: "7375dbe1"
 data:
 {{- range $key, $value := .Values.config.kreferenceMapping }}

--- a/charts/knative-eventing/templates/core/configmaps/leader-election.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/leader-election.yaml
@@ -16,11 +16,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-leader-election
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
   annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
     knative.dev/example-checksum: "f7948630"
 data:
 {{- range $key, $value := .Values.config.leaderElection }}

--- a/charts/knative-eventing/templates/core/configmaps/logging.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/logging.yaml
@@ -16,12 +16,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 data:
 {{- range $key, $value := .Values.config.logging }}
   {{ $key }}: {{ $value | toYaml | indent 4 | trim }}

--- a/charts/knative-eventing/templates/core/configmaps/observability.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/observability.yaml
@@ -16,13 +16,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
   annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
     knative.dev/example-checksum: "f46cf09d"
 data:
 {{- range $key, $value := .Values.config.observability }}

--- a/charts/knative-eventing/templates/core/configmaps/sugar.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/sugar.yaml
@@ -16,11 +16,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-sugar
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
   annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
     knative.dev/example-checksum: "62dfac6f"
 data:
 {{- range $key, $value := .Values.config.sugar }}

--- a/charts/knative-eventing/templates/core/configmaps/tracing.yaml
+++ b/charts/knative-eventing/templates/core/configmaps/tracing.yaml
@@ -16,13 +16,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-tracing
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
   annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
     knative.dev/example-checksum: "0492ceb0"
 data:
 {{- range $key, $value := .Values.config.tracing }}

--- a/charts/knative-eventing/templates/core/deployments/controller.yaml
+++ b/charts/knative-eventing/templates/core/deployments/controller.yaml
@@ -12,17 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $controller := .Values.controller }}
+{{- if $controller.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: eventing-controller
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
     bindings.knative.dev/exclude: "true"
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -32,10 +35,8 @@ spec:
       labels:
         app: eventing-controller
         app.kubernetes.io/component: eventing-controller
-        app.kubernetes.io/version: "1.16.2"
-        app.kubernetes.io/name: knative-eventing
+        {{- include "knative-eventing.labels" . | nindent 8 }}
     spec:
-      # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -45,16 +46,22 @@ spec:
                     app: eventing-controller
                 topologyKey: kubernetes.io/hostname
               weight: 100
-      serviceAccountName: eventing-controller
-      enableServiceLinks: false
+      serviceAccountName: {{ $controller.serviceAccount.name }}
+      enableServiceLinks: {{ $controller.enableServiceLinks }}
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:ae752dc6c90c34d18728cd2f7a24e3712e3b11a20479a32ac23b5982eedfca45
+          image: {{ template "knative-eventing.controller.image" . }}
+          imagePullPolicy: {{ $controller.image.pullPolicy }}
+          {{- with $controller.resources }}
+          resources:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           resources:
             requests:
               cpu: 100m
               memory: 100Mi
+          {{- end }}
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -92,6 +99,10 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+          {{- with $controller.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           livenessProbe:
             httpGet:
               path: /health
@@ -100,6 +111,11 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 5
+          {{- end }}
+          {{- with $controller.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /readiness
@@ -108,10 +124,12 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 5
+          {{- end }}
           ports:
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ $controller.containerPorts.metrics }}
             - name: profiling
-              containerPort: 8008
+              containerPort: {{ $controller.containerPorts.profiling }}
             - name: probes
-              containerPort: 8080
+              containerPort: {{ $controller.containerPorts.probes }}
+{{- end }}

--- a/charts/knative-eventing/templates/core/deployments/job-sink.yaml
+++ b/charts/knative-eventing/templates/core/deployments/job-sink.yaml
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $jobsink := .Values.jobsink }}
+{{- if $jobsink.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: job-sink
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -31,8 +34,7 @@ spec:
       labels:
         sinks.knative.dev/sink: job-sink
         app.kubernetes.io/component: job-sink
-        app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-        app.kubernetes.io/name: knative-eventing
+        {{- include "knative-eventing.labels" . | nindent 8 }}
     spec:
       affinity:
         podAntiAffinity:
@@ -43,11 +45,12 @@ spec:
                     sinks.knative.dev/sink: job-sink
                 topologyKey: kubernetes.io/hostname
               weight: 100
-      enableServiceLinks: false
+      enableServiceLinks: {{ $jobsink.enableServiceLinks }}
       containers:
         - name: job-sink
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:83abe9703e34487a9b53f0fcf08975c08c0a502d60f7fc35f8440c4705045f36
+          image: {{ template "knative-eventing.jobsink.image" . }}
+          imagePullPolicy: {{ $jobsink.image.pullPolicy }}
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -72,39 +75,53 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/internal/eventing
             - name: INGRESS_PORT
-              value: "8080"
+              value: {{ $jobsink.containerPorts.http | quote }}
             - name: INGRESS_PORT_HTTPS
-              value: "8443"
+              value: {{ $jobsink.containerPorts.https | quote }}
+          {{- with $jobsink.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           readinessProbe:
             failureThreshold: 3
             httpGet:
               path: /healthz
-              port: 8080
+              port: http
               scheme: HTTP
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
+          {{- end }}
+          {{- with $jobsink.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /healthz
-              port: 8080
+              port: http
               scheme: HTTP
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
             initialDelaySeconds: 5
+          {{- end }}
           ports:
-            - containerPort: 8080
-              name: http
+            - name: http
+              containerPort: {{ $jobsink.containerPorts.http }}
               protocol: TCP
-            - containerPort: 8443
-              name: https
+            - name: https
+              containerPort: {{ $jobsink.containerPorts.https }}
               protocol: TCP
-            - containerPort: 9092
-              name: metrics
+            - name: metrics
+              containerPort: {{ $jobsink.containerPorts.metrics }}
               protocol: TCP
           terminationMessagePath: /dev/termination-log
+          {{- with $jobsink.resources }}
+          resources:
+          {{- toYaml . | nindent 10 }}
+          {{- else }}
           resources:
             requests:
               cpu: 125m
@@ -112,6 +129,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 2048Mi
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -121,31 +139,33 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
-      serviceAccountName: job-sink
+      serviceAccountName: {{ $jobsink.serviceAccount.name }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  name: job-sink
+  namespace: {{ .Release.Namespace }}
   labels:
     sinks.knative.dev/sink: job-sink
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
-  name: job-sink
-  namespace: "{{ .Release.Namespace }}"
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   ports:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 8080
+      targetPort: {{ $jobsink.containerPorts.http }}
     - name: https
       port: 443
       protocol: TCP
-      targetPort: 8443
+      targetPort: {{ $jobsink.containerPorts.https }}
     - name: http-metrics
       port: 9092
       protocol: TCP
-      targetPort: 9092
+      targetPort: {{ $jobsink.containerPorts.metrics }}
   selector:
     sinks.knative.dev/sink: job-sink
+{{- end }}

--- a/charts/knative-eventing/templates/core/deployments/pingsource-mt-adapter.yaml
+++ b/charts/knative-eventing/templates/core/deployments/pingsource-mt-adapter.yaml
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $mtping := .Values.mtping }}
+{{- if $mtping.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pingsource-mt-adapter
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: pingsource-mt-adapter
-    app.kubernetes.io/version: "1.16.2"
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
     bindings.knative.dev/exclude: "true"
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
   replicas: 0
@@ -35,8 +38,7 @@ spec:
         eventing.knative.dev/source: ping-source-controller
         sources.knative.dev/role: adapter
         app.kubernetes.io/component: pingsource-mt-adapter
-        app.kubernetes.io/version: "1.16.2"
-        app.kubernetes.io/name: knative-eventing
+        {{- include "knative-eventing.labels" . | nindent 8 }}
     spec:
       affinity:
         podAntiAffinity:
@@ -48,10 +50,11 @@ spec:
                     sources.knative.dev/role: adapter
                 topologyKey: kubernetes.io/hostname
               weight: 100
-      enableServiceLinks: false
+      enableServiceLinks: {{ $mtping.enableServiceLinks }}
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:7b05df78d0530813ef41495ba364ba1ef10b7086cc057dabfc68096006da2d6e
+          image: {{ template "knative-eventing.mtping.image" . }}
+          imagePullPolicy: {{ $mtping.image.pullPolicy }}
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -82,9 +85,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           ports:
-            - containerPort: 9090
-              name: metrics
+            - name: metrics
+              containerPort: {{ $mtping.containerPorts.metrics }}
               protocol: TCP
+          {{- with $mtping.resources }}
+          resources:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           resources:
             requests:
               cpu: 125m
@@ -92,6 +99,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 2048Mi
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -101,5 +109,5 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
-      serviceAccountName: pingsource-mt-adapter
-
+      serviceAccountName: {{ $mtping.serviceAccount.name }}
+{{- end }}

--- a/charts/knative-eventing/templates/core/deployments/webhook-hpa.yaml
+++ b/charts/knative-eventing/templates/core/deployments/webhook-hpa.yaml
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $webhook := .Values.webhook }}
+{{- if $webhook.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: eventing-webhook
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -36,19 +39,19 @@ spec:
           type: Utilization
           averageUtilization: 100
 ---
-# Webhook PDB.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: eventing-webhook
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   minAvailable: 80%
   selector:
     matchLabels:
       app: eventing-webhook
-
+{{- end }}

--- a/charts/knative-eventing/templates/core/deployments/webhook.yaml
+++ b/charts/knative-eventing/templates/core/deployments/webhook.yaml
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $webhook := .Values.webhook }}
+{{- if $webhook.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: eventing-webhook
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
     bindings.knative.dev/exclude: "true"
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -33,10 +36,8 @@ spec:
         app: eventing-webhook
         role: eventing-webhook
         app.kubernetes.io/component: eventing-webhook
-        app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-        app.kubernetes.io/name: knative-eventing
+        {{- include "knative-eventing.labels" . | nindent 8 }}
     spec:
-      # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -46,23 +47,25 @@ spec:
                     app: eventing-webhook
                 topologyKey: kubernetes.io/hostname
               weight: 100
-      serviceAccountName: eventing-webhook
-      enableServiceLinks: false
+      serviceAccountName: {{ $webhook.serviceAccount.name }}
+      enableServiceLinks: {{ $webhook.enableServiceLinks }}
       containers:
         - name: eventing-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          # This is the Go import path for the binary that is containerized
-          # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:3f00c566b5a8cb79fff96dfe3c4aa24427c3e2f83665730a4a263b5028d9b802
+          image: {{ template "knative-eventing.webhook.image" . }}
+          imagePullPolicy: {{ $webhook.image.pullPolicy }}
+          {{- with $webhook.resources }}
+          resources:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           resources:
             requests:
-              # taken from serving.
               cpu: 100m
               memory: 50Mi
             limits:
-              # taken from serving.
               cpu: 200m
               memory: 200Mi
+          {{- end }}
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -75,7 +78,7 @@ spec:
             - name: WEBHOOK_NAME
               value: eventing-webhook
             - name: WEBHOOK_PORT
-              value: "8443"
+              value: {{ $webhook.containerPorts.https | quote }}
               # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
               # for the sinkbinding webhook.
               # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
@@ -100,47 +103,58 @@ spec:
               type: RuntimeDefault
           ports:
             - name: https-webhook
-              containerPort: 8443
+              containerPort: {{ $webhook.containerPorts.https }}
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ $webhook.containerPorts.metrics }}
             - name: profiling
-              containerPort: 8008
+              containerPort: {{ $webhook.containerPorts.profiling }}
+          {{- with $webhook.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           readinessProbe:
             periodSeconds: 1
             httpGet:
               scheme: HTTPS
-              port: 8443
+              port: https-webhook
               httpHeaders:
                 - name: k-kubelet-probe
                   value: "webhook"
+          {{- end }}
+          {{- with $webhook.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           livenessProbe:
             periodSeconds: 1
             httpGet:
               scheme: HTTPS
-              port: 8443
+              port: https-webhook
               httpHeaders:
                 - name: k-kubelet-probe
                   value: "webhook"
             initialDelaySeconds: 120
+          {{- end }}
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: {{ $webhook.terminationGracePeriodSeconds }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  name: eventing-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
-  name: eventing-webhook
-  namespace: "{{ .Release.Namespace }}"
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- include "knative-eventing.annotations" . | nindent 4 }}
 spec:
   ports:
     - name: https-webhook
       port: 443
-      targetPort: 8443
+      targetPort: {{ $webhook.containerPorts.https }}
   selector:
     role: eventing-webhook
-
+{{- end }}

--- a/charts/knative-eventing/templates/core/eventing-serviceaccount.yaml
+++ b/charts/knative-eventing/templates/core/eventing-serviceaccount.yaml
@@ -12,26 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $controller := .Values.controller }}
+{{- if and $controller.enabled $controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: eventing-controller
-  namespace: "{{ .Release.Namespace }}"
+  name: {{ $controller.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- with $controller.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-controller
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: knative-eventing-controller
@@ -42,12 +46,11 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-controller
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: addressable-resolver
@@ -58,12 +61,11 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-controller
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: source-observer
@@ -74,12 +76,11 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-controller
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: knative-eventing-sources-controller
@@ -90,12 +91,11 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-controller
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: channelable-manipulator
@@ -106,13 +106,13 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-controller
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: crossnamespace-subscriber
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/knative-eventing/templates/core/job-sink-serviceaccount.yaml
+++ b/charts/knative-eventing/templates/core/job-sink-serviceaccount.yaml
@@ -12,27 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $jobsink := .Values.jobsink }}
+{{- if and $jobsink.enabled $jobsink.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: job-sink
-  namespace: "{{ .Release.Namespace }}"
+  name: {{ $jobsink.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- with $jobsink.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: job-sink
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $jobsink.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: knative-eventing-job-sink
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/knative-eventing/templates/core/pingsource-mt-adapter-serviceaccount.yaml
+++ b/charts/knative-eventing/templates/core/pingsource-mt-adapter-serviceaccount.yaml
@@ -12,27 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $mtping := .Values.mtping }}
+{{- if and $mtping.enabled $mtping.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: pingsource-mt-adapter
-  namespace: "{{ .Release.Namespace }}"
+  name: {{ $mtping.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- with $mtping.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: pingsource-mt-adapter
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $mtping.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: knative-eventing-pingsource-mt-adapter
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/knative-eventing/templates/core/roles/addressable-resolvers-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/addressable-resolvers-clusterrole.yaml
@@ -32,8 +32,7 @@ metadata:
   name: service-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
@@ -51,8 +50,7 @@ metadata:
   name: serving-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
@@ -73,8 +71,7 @@ metadata:
   name: channel-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
@@ -99,8 +96,7 @@ metadata:
   name: broker-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
@@ -119,8 +115,7 @@ metadata:
   name: flows-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
@@ -141,8 +136,7 @@ metadata:
   name: jobsinks-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
@@ -154,4 +148,3 @@ rules:
       - get
       - list
       - watch
-

--- a/charts/knative-eventing/templates/core/roles/broker-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/broker-clusterrole.yaml
@@ -17,8 +17,7 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -43,8 +42,7 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -60,8 +58,7 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/knative-eventing/templates/core/roles/channelable-manipulator-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/channelable-manipulator-clusterrole.yaml
@@ -18,8 +18,7 @@ kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -32,8 +31,7 @@ metadata:
   name: meta-channelable-manipulator
   labels:
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
   - apiGroups:

--- a/charts/knative-eventing/templates/core/roles/clusterrole-namespaced.yaml
+++ b/charts/knative-eventing/templates/core/roles/clusterrole-namespaced.yaml
@@ -18,8 +18,7 @@ metadata:
   name: knative-eventing-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["eventing.knative.dev"]
     resources: ["*"]

--- a/charts/knative-eventing/templates/core/roles/controller-clusterroles.yaml
+++ b/charts/knative-eventing/templates/core/roles/controller-clusterroles.yaml
@@ -17,8 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/knative-eventing/templates/core/roles/crossnamespace-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/crossnamespace-clusterrole.yaml
@@ -18,8 +18,7 @@ kind: ClusterRole
 metadata:
   name: crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -32,8 +31,7 @@ metadata:
   name: channel-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - messaging.knative.dev
@@ -48,8 +46,7 @@ metadata:
   name: broker-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - eventing.knative.dev

--- a/charts/knative-eventing/templates/core/roles/job-sink-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/job-sink-clusterrole.yaml
@@ -17,8 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/knative-eventing/templates/core/roles/pingsource-mt-adapter-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/pingsource-mt-adapter-clusterrole.yaml
@@ -17,8 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/knative-eventing/templates/core/roles/podspecable-binding-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/podspecable-binding-clusterrole.yaml
@@ -18,8 +18,7 @@ kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -32,8 +31,7 @@ metadata:
   name: builtin-podspecable-binding
   labels:
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "podspecable-binding role.
 rules:
   # To patch the subjects of our bindings

--- a/charts/knative-eventing/templates/core/roles/source-observer-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/source-observer-clusterrole.yaml
@@ -18,8 +18,7 @@ kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -32,8 +31,7 @@ metadata:
   name: eventing-sources-source-observer
   labels:
     duck.knative.dev/source: "true"
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # Do not use this role directly. These rules will be added to the "source-observer" role.
 rules:
   - apiGroups:

--- a/charts/knative-eventing/templates/core/roles/sources-controller-clusterroles.yaml
+++ b/charts/knative-eventing/templates/core/roles/sources-controller-clusterroles.yaml
@@ -17,8 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/knative-eventing/templates/core/roles/webhook-clusterrole.yaml
+++ b/charts/knative-eventing/templates/core/roles/webhook-clusterrole.yaml
@@ -17,8 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:

--- a/charts/knative-eventing/templates/core/roles/webhook-role.yaml
+++ b/charts/knative-eventing/templates/core/roles/webhook-role.yaml
@@ -15,11 +15,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 rules:
   # For manipulating certs into secrets.
   - apiGroups:

--- a/charts/knative-eventing/templates/core/webhook-serviceaccount.yaml
+++ b/charts/knative-eventing/templates/core/webhook-serviceaccount.yaml
@@ -12,26 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $webhook := .Values.webhook }}
+{{- if and $webhook.enabled $webhook.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: eventing-webhook
-  namespace: "{{ .Release.Namespace }}"
+  name: {{ $webhook.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
+  annotations:
+    {{- with $webhook.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-webhook
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $webhook.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: knative-eventing-webhook
@@ -40,15 +44,14 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-webhook
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $webhook.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: knative-eventing-webhook
@@ -59,12 +62,11 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-webhook
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $webhook.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: addressable-resolver
@@ -75,13 +77,13 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: eventing-webhook
-    namespace: "{{ .Release.Namespace }}"
+    name: {{ $webhook.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: podspecable-binding
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/knative-eventing/templates/core/webhooks/config-validation.yaml
+++ b/charts/knative-eventing/templates/core/webhooks/config-validation.yaml
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $webhook := .Values.webhook }}
+{{- if $webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: eventing-webhook
-        namespace: "{{ .Release.Namespace }}"
+        namespace: {{ .Release.Namespace }}
     sideEffects: None
     failurePolicy: Ignore
     name: config.webhook.eventing.knative.dev
@@ -34,4 +35,4 @@ webhooks:
           operator: In
           values: ["knative-eventing"]
     timeoutSeconds: 10
-
+{{- end }}

--- a/charts/knative-eventing/templates/core/webhooks/defaulting.yaml
+++ b/charts/knative-eventing/templates/core/webhooks/defaulting.yaml
@@ -17,14 +17,13 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: eventing-webhook
-        namespace: "{{ .Release.Namespace }}"
+        namespace: {{ .Release.Namespace }}
     sideEffects: None
     failurePolicy: Fail
     name: webhook.eventing.knative.dev

--- a/charts/knative-eventing/templates/core/webhooks/resource-validation.yaml
+++ b/charts/knative-eventing/templates/core/webhooks/resource-validation.yaml
@@ -17,14 +17,13 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: eventing-webhook
-        namespace: "{{ .Release.Namespace }}"
+        namespace: {{ .Release.Namespace }}
     sideEffects: None
     failurePolicy: Fail
     name: validation.webhook.eventing.knative.dev

--- a/charts/knative-eventing/templates/core/webhooks/secret.yaml
+++ b/charts/knative-eventing/templates/core/webhooks/secret.yaml
@@ -16,8 +16,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: eventing-webhook-certs
-  namespace: "{{ .Release.Namespace }}"
+  namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 # The data is populated at install time.

--- a/charts/knative-eventing/templates/core/webhooks/sinkbindings.yaml
+++ b/charts/knative-eventing/templates/core/webhooks/sinkbindings.yaml
@@ -17,14 +17,13 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    app.kubernetes.io/version: {{ include "knative-eventing.version" . }}
-    app.kubernetes.io/name: knative-eventing
+    {{- include "knative-eventing.labels" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: eventing-webhook
-        namespace: "{{ .Release.Namespace }}"
+        namespace: {{ .Release.Namespace }}
     failurePolicy: Fail
     sideEffects: None
     name: sinkbindings.webhook.sources.knative.dev

--- a/charts/knative-eventing/values.yaml
+++ b/charts/knative-eventing/values.yaml
@@ -2,6 +2,27 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+##
+global:
+  imageRegistry: ""
+
+## @section Common parameters
+
+## @param nameOverride String to override knative-eventing full name
+##
+nameOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
 
 ## @section knative-eventing configmaps
 
@@ -104,3 +125,290 @@ config:
   ##   debug: "false"
   ##   sampling-rate: "0.1"
   tracing:
+
+## @section knative-eventing deployment
+
+## Knative Eventing Controller
+controller:
+  ## @param controller.enabled Enable eventing controller container deployment
+  ##
+  enabled: true
+  ## Knative Eventing Controller image
+  ## @param controller.image.registry Controller image registry
+  ## @param controller.image.repository Controller image repository
+  ## @param controller.image.tag Controller image tag
+  ## @param controller.image.digest Controller image digest
+  ## @param controller.image.pullPolicy Controller image pull policy
+  ## @param controller.image.pullSecrets Controller image pull secrets
+  ##
+  image:
+    registry: gcr.io/knative-releases
+    repository: knative.dev/eventing/cmd/controller
+    tag: ""
+    digest: sha256:ae752dc6c90c34d18728cd2f7a24e3712e3b11a20479a32ac23b5982eedfca45
+    pullPolicy: IfNotPresent
+  ## @param controller.containerPorts.metrics
+  ## @param controller.containerPorts.profiling
+  ## @param controller.containerPorts.probes
+  ##
+  containerPorts:
+    metrics: 9090
+    profiling: 8008
+    probes: 8080
+  ## @param controller.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param controller.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ## @param controller.serviceAccount.annotations Annotations to add to the ServiceAccount Metadata
+  ##
+  serviceAccount:
+    create: true
+    name: eventing-controller
+    annotations: {}
+  ## @param controller.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ## resources:
+  ##   requests:
+  ##     cpu: 100m
+  ##     memory: 100Mi
+  ##   limits:
+  ##     cpu: 100m
+  ##     memory: 100Mi
+  ##
+  resources: {}
+  ## Eventing controller containers' liveness probe
+  ## @param controller.livenessProbe Set the liveness probe for the controller container
+  ## e.g:
+  ## livenessProbe:
+  ##   httpGet:
+  ##     path: /health
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   initialDelaySeconds: 20
+  ##   periodSeconds: 10
+  ##   timeoutSeconds: 5
+  ##
+  livenessProbe: {}
+  ## Eventing controller containers' readiness probe
+  ## @param controller.readinessProbe Set the readiness probe for the controller container
+  ## e.g:
+  ## readinessProbe:
+  ##   httpGet:
+  ##     path: /readiness
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   initialDelaySeconds: 20
+  ##   periodSeconds: 10
+  ##   timeoutSeconds: 5
+  ##
+  readinessProbe: {}
+  ## @param controller.enableServiceLinks Whether information about services should be injected into pod's environment variable
+  ## The environment variables injected by service links are not used, but can lead to slow boot times or slow running of the scripts when there are many services in the current namespace.
+  ## If you experience slow pod startups or slow running of the scripts you probably want to set this to `false`.
+  ##
+  enableServiceLinks: false
+
+## Knative Eventing Job Sink
+jobsink:
+  ## @param jobsink.enabled Enable eventing Job Sink container deployment
+  ##
+  enabled: true
+  ## Knative Eventing Job Sink image
+  ## @param jobsink.image.registry Job Sink image registry
+  ## @param jobsink.image.repository Job Sink image repository
+  ## @param jobsink.image.tag Job Sink image tag
+  ## @param jobsink.image.digest Job Sink image digest
+  ## @param jobsink.image.pullPolicy Job Sink image pull policy
+  ## @param jobsink.image.pullSecrets Job Sink image pull secrets
+  ##
+  image:
+    registry: gcr.io
+    repository: knative-releases/knative.dev/eventing/cmd/jobsink
+    tag: ""
+    digest: sha256:83abe9703e34487a9b53f0fcf08975c08c0a502d60f7fc35f8440c4705045f36
+    pullPolicy: IfNotPresent
+  ## @param jobsink.containerPorts.http
+  ## @param jobsink.containerPorts.https
+  ## @param jobsink.containerPorts.metrics
+  ##
+  containerPorts:
+    http: 8080
+    https: 8443
+    metrics: 9092
+  ## @param jobsink.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param jobsink.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ## @param jobsink.serviceAccount.annotations Annotations to add to the ServiceAccount Metadata
+  ##
+  serviceAccount:
+    create: true
+    name: job-sink
+    annotations: {}
+  ## @param jobsink.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ##  resources:
+  ##   requests:
+  ##     cpu: 125m
+  ##     memory: 64Mi
+  ##   limits:
+  ##      cpu: 1000m
+  ##      memory: 2048Mi
+  ##
+  resources: {}
+  ## Eventing Job Sink containers' liveness probe
+  ## @param jobsink.livenessProbe Set the liveness probe for the Job Sink container
+  ## e.g:
+  ## livenessProbe:
+  ##   httpGet:
+  ##     path: /health
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   initialDelaySeconds: 20
+  ##   periodSeconds: 10
+  ##   timeoutSeconds: 5
+  ##
+  livenessProbe: {}
+  ## Eventing jobsink containers' readiness probe
+  ## @param jobsink.readinessProbe Set the readiness probe for the Job Sink container
+  ## e.g:
+  ## readinessProbe:
+  ##   httpGet:
+  ##     path: /readiness
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   initialDelaySeconds: 20
+  ##   periodSeconds: 10
+  ##   timeoutSeconds: 5
+  ##
+  readinessProbe: {}
+  ## @param jobsink.enableServiceLinks Whether information about services should be injected into pod's environment variable
+  ## The environment variables injected by service links are not used, but can lead to slow boot times or slow running of the scripts when there are many services in the current namespace.
+  ## If you experience slow pod startups or slow running of the scripts you probably want to set this to `false`.
+  ##
+  enableServiceLinks: false
+
+## Knative Eventing Ping Source MT Adapter
+mtping:
+  ## @param mtping.enabled Enable Ping Source MT Adapter container deployment
+  ##
+  enabled: true
+  ## Knative Eventing Ping Source MT Adapter image
+  ## @param mtping.imagse.registry Ping Source MT Adapter image registry
+  ## @param mtping.image.repository Ping Source MT Adapter image repository
+  ## @param mtping.image.tag Ping Source MT Adapter image tag
+  ## @param mtping.image.digest Ping Source MT Adapter image digest
+  ## @param mtping.image.pullPolicy Ping Source MT Adapter image pull policy
+  ## @param mtping.image.pullSecrets Ping Source MT Adapter image pull secrets
+  ##
+  image:
+    registry: gcr.io
+    repository: knative-releases/knative.dev/eventing/cmd/mtping
+    tag: ""
+    digest: sha256:7b05df78d0530813ef41495ba364ba1ef10b7086cc057dabfc68096006da2d6e
+    pullPolicy: IfNotPresent
+  ## @param mtping.containerPorts.metrics
+  ##
+  containerPorts:
+    metrics: 9090
+  ## @param mtping.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param mtping.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ## @param mtping.serviceAccount.annotations Annotations to add to the ServiceAccount Metadata
+  ##
+  serviceAccount:
+    create: true
+    name: pingsource-mt-adapter
+    annotations: {}
+  ## @param mtping.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ##  resources:
+  ##   requests:
+  ##     cpu: 125m
+  ##     memory: 64Mi
+  ##   limits:
+  ##      cpu: 1000m
+  ##      memory: 2048Mi
+  ##
+  resources: {}
+  ## @param mtping.enableServiceLinks Whether information about services should be injected into pod's environment variable
+  ## The environment variables injected by service links are not used, but can lead to slow boot times or slow running of the scripts when there are many services in the current namespace.
+  ## If you experience slow pod startups or slow running of the scripts you probably want to set this to `false`.
+  ##
+  enableServiceLinks: false
+
+## Knative Eventing Webhook
+webhook:
+  ## @param webhook.enabled Enable eventing webhook container deployment
+  ##
+  enabled: true
+  ## Knative Eventing Webhook image
+  ## @param webhook.image.registry Eventing Webhook image registry
+  ## @param webhook.image.repository Eventing Webhook image repository
+  ## @param webhook.image.tag Eventing Webhook image tag
+  ## @param webhook.image.digest Eventing Webhook image digest
+  ## @param webhook.image.pullPolicy Eventing Webhook image pull policy
+  ## @param webhook.image.pullSecrets Eventing Webhook image pull secrets
+  ##
+  image:
+    registry: gcr.io
+    repository: knative-releases/knative.dev/eventing/cmd/webhook
+    tag: ""
+    digest: sha256:3f00c566b5a8cb79fff96dfe3c4aa24427c3e2f83665730a4a263b5028d9b802
+    pullPolicy: IfNotPresent
+  ## @param webhook.containerPorts.https
+  ## @param webhook.containerPorts.metrics
+  ## @param webhook.containerPorts.profiling
+  ##
+  containerPorts:
+    https: 8443
+    metrics: 9090
+    profiling: 8008
+  ## @param webhook.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param webhook.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ## @param webhook.serviceAccount.annotations Annotations to add to the ServiceAccount Metadata
+  ##
+  serviceAccount:
+    create: true
+    name: eventing-webhook
+    annotations: {}
+  ## @param webhook.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ##  resources:
+  ##   requests:
+  ##     cpu: 125m
+  ##     memory: 64Mi
+  ##   limits:
+  ##      cpu: 1000m
+  ##      memory: 2048Mi
+  ##
+  resources: {}
+  ## Eventing Webhook containers' liveness probe
+  ## @param webhook.livenessProbe Set the liveness probe for the Webhook container
+  ## e.g:
+  ## livenessProbe:
+  ##   httpGet:
+  ##     path: /health
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   initialDelaySeconds: 20
+  ##   periodSeconds: 10
+  ##   timeoutSeconds: 5
+  ##
+  livenessProbe: {}
+  ## Eventing Webhook containers' readiness probe
+  ## @param webhook.readinessProbe Set the readiness probe for the Webhook container
+  ## e.g:
+  ## readinessProbe:
+  ##   httpGet:
+  ##     path: /readiness
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   initialDelaySeconds: 20
+  ##   periodSeconds: 10
+  ##   timeoutSeconds: 5
+  ##
+  readinessProbe: {}
+  ## @param webhook.enableServiceLinks Whether information about services should be injected into pod's environment variable
+  ## The environment variables injected by service links are not used, but can lead to slow boot times or slow running of the scripts when there are many services in the current namespace.
+  ## If you experience slow pod startups or slow running of the scripts you probably want to set this to `false`.
+  ##
+  enableServiceLinks: false
+  ## @param webhook.terminationGracePeriodSeconds The period of time in seconds after the webhook container receives a termination signal before the container should be terminated
+  ##
+  terminationGracePeriodSeconds: 300


### PR DESCRIPTION
Within the knative-eventing chart the main objective is to add values for the controller, jobsink, pingsource adapter and webhook similar to bitnami charts. Additionally added `containerPorts`, `serviceAccount`, `resources`, `livenessProbe`, `readinessProbe`, `enableServiceLinks` and `terminationGracePeriodSeconds` where applicable.