### PR TITLE
fix(ci): ghcr path set to lowercase

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - main
+      - 'main'
 
 jobs:
   release:
@@ -69,5 +69,5 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+            helm push "${pkg}" "oci://ghcr.io/$(echo ${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]')"
           done


### PR DESCRIPTION
`GITHUB_REPOSITORY_OWNER` can include usercase characters which causes helm push to fail; hence setting to lowercase and switching to `GITHUB_REPOSITORY`