### PR TITLE
feat: define range of values for each serving component

### DIFF
--- a/charts/knative-serving/Chart.yaml
+++ b/charts/knative-serving/Chart.yaml
@@ -22,4 +22,4 @@ name: knative-serving
 sources:
   - https://github.com/Ahhhh-man/charts/tree/main/charts/knative-serving
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/charts/knative-serving/templates/_helpers.tpl
+++ b/charts/knative-serving/templates/_helpers.tpl
@@ -117,3 +117,17 @@ Return the proper webhook image name
 {{- define "knative-serving.webhook.image" -}}
 {{- include "common.images.image" (dict "imageRoot" .Values.webhook.image "global" .Values.global) -}}
 {{- end -}}
+
+{{/*
+Formats imagePullSecrets. Input is (dict "root" . "imagePullSecrets" .{specific imagePullSecrets})
+*/}}
+{{- define "knative-serving.imagePullSecrets" -}}
+{{- $root := .root }}
+{{- range (concat .root.Values.global.imagePullSecrets .imagePullSecrets) }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml (dict "name" (tpl .name $root)) | trim }}
+{{- else }}
+- name: {{ tpl . $root }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/knative-serving/templates/core/deployments/activator-hpa.yaml
+++ b/charts/knative-serving/templates/core/deployments/activator-hpa.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $activator := .Values.activator }}
+{{- if $activator.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -56,3 +58,4 @@ spec:
   selector:
     matchLabels:
       app: activator
+{{- end }}

--- a/charts/knative-serving/templates/core/deployments/activator.yaml
+++ b/charts/knative-serving/templates/core/deployments/activator.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $activator := .Values.activator }}
+{{- if $activator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,10 +35,16 @@ spec:
         app: activator
         role: activator
         app.kubernetes.io/component: activator
-        app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: {{ include "knative-serving.version" . }}
+        {{ include "knative-serving.labels" . | nindent 8 }}
     spec:
-      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      {{- with $activator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- with $activator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 12 }}
+      {{- else }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -46,13 +54,24 @@ spec:
                     app: activator
                 topologyKey: kubernetes.io/hostname
               weight: 100
-      serviceAccountName: activator
+      {{- end }}
+      {{- with $activator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+      serviceAccountName: {{ $activator.serviceAccount.name }}
       containers:
         - name: activator
           image: {{ template "knative-serving.activator.image" . }}
-          imagePullPolicy: {{ .Values.activator.image.pullPolicy }}
-          # The numbers are based on performance test results from
-          # https://github.com/knative/serving/issues/1625#issuecomment-511930023
+          imagePullPolicy: {{ $activator.image.pullPolicy }}
+          {{- if or $activator.image.pullSecrets .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- include "knative-serving.imagePullSecrets" (dict "root" . "imagePullSecrets" $activator.image.pullSecrets) | nindent 8 }}
+          {{- end }}
+          {{- with $activator.resources }}
+          resources:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           resources:
             requests:
               cpu: 300m
@@ -60,6 +79,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 600Mi
+          {{- end }}
           env:
             # Run Activator with GC collection when newly generated memory is 500%.
             - name: GOGC
@@ -94,24 +114,35 @@ spec:
               type: RuntimeDefault
           ports:
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ $activator.containerPorts.metrics }}
             - name: profiling
-              containerPort: 8008
+              containerPort: {{ $activator.containerPorts.profiling }}
             - name: http1
-              containerPort: 8012
+              containerPort: {{ $activator.containerPorts.http1 }}
             - name: h2c
-              containerPort: 8013
-          readinessProbe:
-            httpGet:
-              port: 8012
-            periodSeconds: 5
-            failureThreshold: 5
+              containerPort: {{ $activator.containerPorts.h2c }}
+          {{- with $activator.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           livenessProbe:
             httpGet:
-              port: 8012
+              port: http1
             periodSeconds: 10
             failureThreshold: 12
             initialDelaySeconds: 15
+          {{- end }}
+          {{- with $activator.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }} 
+          readinessProbe:
+            httpGet:
+              port: http1
+            periodSeconds: 5
+            failureThreshold: 5
+            initialDelaySeconds: 15
+          {{- end }}
       # The activator (often) sits on the dataplane, and may proxy long (e.g.
       # streaming, websockets) requests.  We give a long grace period for the
       # activator to "lame duck" and drain outstanding requests before we
@@ -119,7 +150,7 @@ spec:
       # should be at least as large as the upper bound on the Revision's
       # timeoutSeconds property to avoid servicing events disrupting
       # connections.
-      terminationGracePeriodSeconds: 600
+      terminationGracePeriodSeconds: {{ $activator.terminationGracePeriodSeconds }}
 ---
 apiVersion: v1
 kind: Service
@@ -135,20 +166,20 @@ spec:
   selector:
     app: activator
   ports:
-    # Define metrics and profiling for them to be accessible within service meshes.
     - name: http-metrics
       port: 9090
-      targetPort: 9090
+      targetPort: {{ $activator.containerPorts.metrics }}
     - name: http-profiling
       port: 8008
-      targetPort: 8008
+      targetPort: {{ $activator.containerPorts.profiling }}
     - name: http
       port: 80
-      targetPort: 8012
+      targetPort: {{ $activator.containerPorts.http1 }}
     - name: http2
       port: 81
-      targetPort: 8013
+      targetPort: {{ $activator.containerPorts.h2c }}
     - name: https
       port: 443
-      targetPort: 8112
+      targetPort: {{ $activator.containerPorts.https }}
   type: ClusterIP
+{{- end }}

--- a/charts/knative-serving/templates/core/deployments/autoscaler.yaml
+++ b/charts/knative-serving/templates/core/deployments/autoscaler.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $autoscaler := .Values.autoscaler }}
+{{- if $autoscaler.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,7 +25,7 @@ metadata:
   annotations:
     {{ include "knative-serving.annotations" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ $autoscaler.replicas }}
   selector:
     matchLabels:
       app: autoscaler
@@ -36,10 +38,16 @@ spec:
       labels:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
-        app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: {{ include "knative-serving.version" . }}
+        {{ include "knative-serving.labels" . | nindent 8 }}
     spec:
-      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      {{- with $autoscaler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- with $autoscaler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 12 }}
+      {{- else }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -49,11 +57,24 @@ spec:
                     app: autoscaler
                 topologyKey: kubernetes.io/hostname
               weight: 100
+      {{- end }}
+      {{- with $autoscaler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       serviceAccountName: controller
       containers:
         - name: autoscaler
           image: {{ template "knative-serving.autoscaler.image" . }}
-          imagePullPolicy: {{ .Values.autoscaler.image.pullPolicy }}
+          imagePullPolicy: {{ $autoscaler.image.pullPolicy }}
+          {{- if or $autoscaler.image.pullSecrets .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- include "knative-serving.imagePullSecrets" (dict "root" . "imagePullSecrets" $autoscaler.image.pullSecrets) | nindent 8 }}
+          {{- end }}
+          {{- with $autoscaler.resources }}
+          resources:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           resources:
             requests:
               cpu: 100m
@@ -61,6 +82,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 1000Mi
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -92,18 +114,28 @@ spec:
               type: RuntimeDefault
           ports:
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ $autoscaler.containerPorts.metrics }}
             - name: profiling
-              containerPort: 8008
+              containerPort: {{ $autoscaler.containerPorts.profiling }}
             - name: websocket
-              containerPort: 8080
-          readinessProbe:
-            httpGet:
-              port: 8080
+              containerPort: {{ $autoscaler.containerPorts.websocket }}
+          {{- with $autoscaler.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           livenessProbe:
             httpGet:
-              port: 8080
+              port: websocket
             failureThreshold: 6
+          {{- end }}
+          {{- with $autoscaler.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }} 
+          readinessProbe:
+            httpGet:
+              port: websocket
+          {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -116,17 +148,17 @@ metadata:
     {{ include "knative-serving.labels" . | nindent 4 }}
   annotations:
     {{ include "knative-serving.annotations" . | nindent 4 }}
-spec:
-  ports:
-    # Define metrics and profiling for them to be accessible within service meshes.
-    - name: http-metrics
-      port: 9090
-      targetPort: 9090
-    - name: http-profiling
-      port: 8008
-      targetPort: 8008
-    - name: http
-      port: 8080
-      targetPort: 8080
+spec:  
   selector:
     app: autoscaler
+  ports:
+    - name: http-metrics
+      port: 9090
+      targetPort: {{ $autoscaler.containerPorts.metrics }}
+    - name: http-profiling
+      port: 8008
+      targetPort: {{ $autoscaler.containerPorts.profiling }}
+    - name: http
+      port: 8080
+      targetPort: {{ $autoscaler.containerPorts.websocket }}
+{{- end }}

--- a/charts/knative-serving/templates/core/deployments/controller.yaml
+++ b/charts/knative-serving/templates/core/deployments/controller.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $controller := .Values.controller }}
+{{- if $controller.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,8 +21,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: {{ include "knative-serving.version" . }}
+    {{ include "knative-serving.labels" . | nindent 4 }}
+  annotations:
+    {{ include "knative-serving.annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -30,10 +33,16 @@ spec:
       labels:
         app: controller
         app.kubernetes.io/component: controller
-        app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: {{ include "knative-serving.version" . }}
+        {{ include "knative-serving.labels" . | nindent 8 }}
     spec:
-      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      {{- with $controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- with $controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 12 }}
+      {{- else }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -43,11 +52,24 @@ spec:
                     app: controller
                 topologyKey: kubernetes.io/hostname
               weight: 100
-      serviceAccountName: controller
+      {{- end }}
+      {{- with $controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+      serviceAccountName: {{ $controller.serviceAccount.name }}
       containers:
         - name: controller
           image: {{ template "knative-serving.controller.image" . }}
-          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          imagePullPolicy: {{ $controller.image.pullPolicy }}
+          {{- if or $controller.image.pullSecrets .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- include "knative-serving.imagePullSecrets" (dict "root" . "imagePullSecrets" $controller.image.pullSecrets) | nindent 8 }}
+          {{- end }}
+          {{- with $controller.resources }}
+          resources:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           resources:
             requests:
               cpu: 100m
@@ -55,6 +77,7 @@ spec:
             limits:
               cpu: 1000m
               memory: 1000Mi
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -80,6 +103,17 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+          ports:
+            - name: metrics
+              containerPort: {{ $controller.containerPorts.metrics }}
+            - name: profiling
+              containerPort: {{ $controller.containerPorts.profiling }}
+            - name: probes
+              containerPort: {{ $controller.containerPorts.probes }}
+          {{- with $controller.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           livenessProbe:
             httpGet:
               path: /health
@@ -87,6 +121,11 @@ spec:
               scheme: HTTP
             periodSeconds: 5
             failureThreshold: 6
+          {{- end }}
+          {{- with $controller.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }} 
           readinessProbe:
             httpGet:
               path: /readiness
@@ -94,13 +133,7 @@ spec:
               scheme: HTTP
             periodSeconds: 5
             failureThreshold: 3
-          ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
-            - name: probes
-              containerPort: 8080
+          {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -115,12 +148,12 @@ metadata:
     {{ include "knative-serving.annotations" . | nindent 4 }}
 spec:
   ports:
-    # Define metrics and profiling for them to be accessible within service meshes.
     - name: http-metrics
       port: 9090
-      targetPort: 9090
+      targetPort: {{ $controller.containerPorts.metrics }}
     - name: http-profiling
       port: 8008
-      targetPort: 8008
+      targetPort: {{ $controller.containerPorts.profiling }}
   selector:
     app: controller
+{{- end }}

--- a/charts/knative-serving/templates/core/deployments/webhook-hpa.yaml
+++ b/charts/knative-serving/templates/core/deployments/webhook-hpa.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $webhook := .Values.webhook }}
+{{- if $webhook.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -54,3 +56,4 @@ spec:
   selector:
     matchLabels:
       app: webhook
+{{- end }}

--- a/charts/knative-serving/templates/core/deployments/webhook.yaml
+++ b/charts/knative-serving/templates/core/deployments/webhook.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $webhook := .Values.webhook }}
+{{- if $webhook.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,9 +35,16 @@ spec:
         app: webhook
         role: webhook
         app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: {{ include "knative-serving.version" . }}
-        app.kubernetes.io/name: knative-serving
-    spec:
+        {{ include "knative-serving.labels" . | nindent 8 }}
+    spec:      
+      {{- with $webhook.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- with $webhook.affinity }}
+      affinity:
+        {{- toYaml . | nindent 12 }}
+      {{- else }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -45,11 +54,24 @@ spec:
                     app: webhook
                 topologyKey: kubernetes.io/hostname
               weight: 100
+      {{- end }}
+      {{- with $webhook.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       serviceAccountName: controller
       containers:
         - name: webhook
           image: {{ template "knative-serving.webhook.image" . }}
-          imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
+          imagePullPolicy: {{ $webhook.image.pullPolicy }}
+          {{- if or $webhook.image.pullSecrets .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- include "knative-serving.imagePullSecrets" (dict "root" . "imagePullSecrets" $webhook.image.pullSecrets) | nindent 8 }}
+          {{- end }}
+          {{- with $webhook.resources }}
+          resources:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           resources:
             requests:
               cpu: 100m
@@ -57,6 +79,7 @@ spec:
             limits:
               cpu: 500m
               memory: 500Mi
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -88,26 +111,36 @@ spec:
               type: RuntimeDefault
           ports:
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ $webhook.containerPorts.metrics }}
             - name: profiling
-              containerPort: 8008
+              containerPort: {{ $webhook.containerPorts.profiling }}
             - name: https-webhook
-              containerPort: 8443
-          readinessProbe:
-            periodSeconds: 1
-            httpGet:
-              scheme: HTTPS
-              port: 8443
+              containerPort: {{ $webhook.containerPorts.https }}
+          {{- with $webhook.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }}
           livenessProbe:
             periodSeconds: 10
             httpGet:
               scheme: HTTPS
-              port: 8443
+              port: https-webhook
             failureThreshold: 6
             initialDelaySeconds: 20
+          {{- end }}
+          {{- with $webhook.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 6 }}
+          {{- else }} 
+          readinessProbe:
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: https-webhook
+          {{- end }}
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: {{ $webhook.terminationGracePeriodSeconds }}
 ---
 apiVersion: v1
 kind: Service
@@ -121,17 +154,18 @@ metadata:
     {{ include "knative-serving.labels" . | nindent 4 }}
   annotations:
     {{ include "knative-serving.annotations" . | nindent 4 }}
-spec:
-  ports:
-    - name: http-metrics
-      port: 9090
-      targetPort: 9090
-    - name: http-profiling
-      port: 8008
-      targetPort: 8008
-    - name: https-webhook
-      port: 443
-      targetPort: 8443
+spec:  
   selector:
     app: webhook
     role: webhook
+  ports:
+    - name: http-metrics
+      port: 9090
+      targetPort: {{ $webhook.containerPorts.metrics }}
+    - name: http-profiling
+      port: 8008
+      targetPort: {{ $webhook.containerPorts.profiling }}
+    - name: https-webhook
+      port: 443
+      targetPort: {{ $webhook.containerPorts.https }}
+{{- end }}

--- a/charts/knative-serving/templates/core/serviceaccounts/activator.yaml
+++ b/charts/knative-serving/templates/core/serviceaccounts/activator.yaml
@@ -1,0 +1,54 @@
+
+{{- $activator := .Values.activator }}
+{{- if and $activator.enabled $activator.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $activator.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: activator
+    {{ include "knative-serving.labels" . | nindent 4 }}
+  annotations:
+    {{ include "knative-serving.annotations" . | nindent 4 }}
+    {{- with $activator.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: knative-serving-activator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: activator
+    {{ include "knative-serving.labels" . | nindent 4 }}
+  annotations:
+    {{ include "knative-serving.annotations" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $activator.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: knative-serving-activator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-activator-cluster
+  labels:
+    app.kubernetes.io/component: activator
+    {{ include "knative-serving.labels" . | nindent 4 }}
+  annotations:
+    {{ include "knative-serving.annotations" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $activator.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-activator-cluster
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/knative-serving/templates/core/serviceaccounts/controller.yaml
+++ b/charts/knative-serving/templates/core/serviceaccounts/controller.yaml
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $controller := .Values.controller }}
+{{- if and $controller.enabled $controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller
+  name: {{ $controller.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller
@@ -47,7 +49,7 @@ metadata:
     {{ include "knative-serving.annotations" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: controller
+    name: {{ $controller.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -65,57 +67,10 @@ metadata:
     {{ include "knative-serving.annotations" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: controller
+    name: {{ $controller.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: knative-serving-aggregated-addressable-resolver
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: activator
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/component: activator
-    {{ include "knative-serving.labels" . | nindent 4 }}
-  annotations:
-    {{ include "knative-serving.annotations" . | nindent 4 }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: knative-serving-activator
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/component: activator
-    {{ include "knative-serving.labels" . | nindent 4 }}
-  annotations:
-    {{ include "knative-serving.annotations" . | nindent 4 }}
-subjects:
-  - kind: ServiceAccount
-    name: activator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: knative-serving-activator
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: knative-serving-activator-cluster
-  labels:
-    app.kubernetes.io/component: activator
-    {{ include "knative-serving.labels" . | nindent 4 }}
-  annotations:
-    {{ include "knative-serving.annotations" . | nindent 4 }}
-subjects:
-  - kind: ServiceAccount
-    name: activator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: knative-serving-activator-cluster
-  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/knative-serving/values.yaml
+++ b/charts/knative-serving/values.yaml
@@ -3,9 +3,15 @@
 # license that can be found in the LICENSE file.
 
 ## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
 ##
 global:
   imageRegistry: ""
+  ## e.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
 
 ## @section Common parameters
 
@@ -29,56 +35,362 @@ crds:
 ## @section knative-serving configmaps
 ##
 config:
-  autoscaler:
-  certmanager:
-  defaults:
-  deployment:
-  domain:
-    ## NOTE: use `|` due empty string being omitted
-    ## example.com: |
-    ##  ""
-  features:
-  gc:
-  leaderElection:
-  logging:
-  network:
-  observability:
-  tracing:
+  autoscaler: {}
+  certmanager: {}
+  defaults: {}
+  deployment: {}
+  domain: {}
+  features: {}
+  gc: {}
+  leaderElection: {}
+  logging: {}
+  network: {}
+  observability: {}
+  tracing: {}
 
-## @section knative-serving components
-##
+## @section Knative Serving Components
+
+## Knative Serving Activator
 activator:
+  ## @param controller.enabled Enable Activator container deployment
+  ##
+  enabled: true
+  ## Knative Serving Activator image
+  ## @param activator.image.registry Activator image registry
+  ## @param activator.image.repository Activator image repository
+  ## @param activator.image.tag Activator image tag
+  ## @param activator.image.digest Activator image digest
+  ## @param activator.image.pullPolicy Activator image pull policy
+  ## @param activator.image.pullSecrets Activator image pull secrets
+  ##
   image:
-    registry: gcr.io/knative-releases
-    repository: knative.dev/serving/cmd/activator
+    registry: gcr.io
+    repository: knative-releases/knative.dev/serving/cmd/activator
     tag: ""
     digest: sha256:24c19cbee078925b91cd2e85082b581d53b218b410c083b1005dc06dc549b1d3
     pullPolicy: IfNotPresent
+    ## e.g.
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
     pullSecrets: []
+  ## @param activator.containerPorts.metrics
+  ## @param activator.containerPorts.profiling
+  ## @param activator.containerPorts.http1
+  ## @param activator.containerPorts.h2c
+  ## @param activator.containerPorts.https
+  ##
+  containerPorts:
+    metrics: 9090
+    profiling: 8008
+    http1: 8012
+    h2c: 8013
+    https: 8112
+  ## @param activator.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param activator.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ## @param activator.serviceAccount.annotations Annotations to add to the ServiceAccount Metadata
+  ##
+  serviceAccount:
+    create: true
+    name: activator
+    annotations: {}
+  ## @param activator.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ## resources:
+  ##   requests:
+  ##     cpu: 300m
+  ##     memory: 60Mi
+  ##   limits:
+  ##     cpu: 1000m
+  ##     memory: 600Mi
+  ##
+  resources: {}
+  ## Activator containers' liveness probe
+  ## @param activator.livenessProbe Set the liveness probe for the Activator container
+  ## e.g:
+  ## livenessProbe:
+  ##   httpGet:
+  ##     port: http1
+  ##   periodSeconds: 10
+  ##   failureThreshold: 12
+  ##   initialDelaySeconds: 15
+  ##
+  livenessProbe: {}
+  ## Activator containers' readiness probe
+  ## @param activator.readinessProbe Set the readiness probe for the Activator container
+  ## e.g:
+  ## readinessProbe:
+  ##   httpGet:
+  ##     port: http1
+  ##   periodSeconds: 5
+  ##   failureThreshold: 5
+  ##
+  readinessProbe: {}
+  ## @param activator.affinity Affinity for Activator pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+  ## @param activator.nodeSelector Node labels for Activator pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ##
+  nodeSelector: {}
+  ## @param activator.tolerations Tolerations for Activator pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param activator.terminationGracePeriodSeconds The period of time in seconds after the webhook container receives a termination signal before the container should be terminated
+  ##
+  terminationGracePeriodSeconds: 300
 
+## Knative Serving Autoscaler
 autoscaler:
+  ## @param autoscaler.enabled Enable Autoscaler container deployment
+  ##
+  enabled: true
+  ## @param autoscaler.replicas Number of Autoscaler
+  ##
+  replicas: 1
+  ## Knative Serving Autoscaler image
+  ## @param autoscaler.image.registry Autoscaler image registry
+  ## @param autoscaler.image.repository Autoscaler image repository
+  ## @param autoscaler.image.tag Autoscaler image tag
+  ## @param autoscaler.image.digest Autoscaler image digest
+  ## @param autoscaler.image.pullPolicy Autoscaler image pull policy
+  ## @param autoscaler.image.pullSecrets Autoscaler image pull secrets
+  ##
   image:
-    registry: gcr.io/knative-releases
-    repository: knative.dev/serving/cmd/autoscaler
+    registry: gcr.io
+    repository: knative-releases/knative.dev/serving/cmd/autoscaler
     tag: ""
     digest: sha256:5e9236452d89363957d4e7e249d57740a8fcd946aed23f8518d94962bf440250
     pullPolicy: IfNotPresent
+    ## e.g.
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
     pullSecrets: []
+  ## @param autoscaler.containerPorts.metrics
+  ## @param autoscaler.containerPorts.profiling
+  ## @param autoscaler.containerPorts.websocket
+  ##
+  containerPorts:
+    metrics: 9090
+    profiling: 8008
+    websocket: 8080
+  ## @param autoscaler.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ##
+  serviceAccount:
+    name: controller
+  ## @param autoscaler.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ## resources:
+  ##   requests:
+  ##     cpu: 100m
+  ##     memory: 100Mi
+  ##   limits:
+  ##     cpu: 1000m
+  ##     memory: 1000Mi
+  ##
+  resources: {}
+  ## Autoscaler containers' liveness probe
+  ## @param autoscaler.livenessProbe Set the liveness probe for the Autoscaler container
+  ## e.g:
+  ## livenessProbe:
+  ##   httpGet:
+  ##     port: websocket
+  ##   failureThreshold: 6
+  ##
+  livenessProbe: {}
+  ## Autoscaler containers' readiness probe
+  ## @param autoscaler.readinessProbe Set the readiness probe for the Autoscaler container
+  ## e.g:
+  ## readinessProbe:
+  ##   httpGet:
+  ##     port: websocket
+  ##
+  readinessProbe: {}
+  ## @param autoscaler.affinity Affinity for Autoscaler pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+  ## @param autoscaler.nodeSelector Node labels for Autoscaler pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ##
+  nodeSelector: {}
+  ## @param autoscaler.tolerations Tolerations for Autoscaler pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
+## Knative Serving Controller
 controller:
+  ## @param controller.enabled Enable Controller container deployment
+  ##
+  enabled: true
+  ## Knative Serving Controller image
+  ## @param controller.image.registry Controller image registry
+  ## @param controller.image.repository Controller image repository
+  ## @param controller.image.tag Controller image tag
+  ## @param controller.image.digest Controller image digest
+  ## @param controller.image.pullPolicy Controller image pull policy
+  ## @param controller.image.pullSecrets Controller image pull secrets
+  ##
   image:
-    registry: gcr.io/knative-releases
-    repository: knative.dev/serving/cmd/controller
+    registry: gcr.io
+    repository: knative-releases/knative.dev/serving/cmd/controller
     tag: ""
     digest: sha256:5fb22b052e6bc98a1a6bbb68c0282ddb50744702acee6d83110302bc990666e9
     pullPolicy: IfNotPresent
+    ## e.g.
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
     pullSecrets: []
+  ## @param controller.containerPorts.metrics
+  ## @param controller.containerPorts.profiling
+  ## @param controller.containerPorts.probes
+  ##
+  containerPorts:
+    metrics: 9090
+    profiling: 8008
+    probes: 8080
+  ## @param controller.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param controller.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ## @param controller.serviceAccount.annotations Annotations to add to the ServiceAccount Metadata
+  ##
+  serviceAccount:
+    create: true
+    name: controller
+    annotations: {}
+  ## @param controller.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ## resources:
+  ##   requests:
+  ##     cpu: 100m
+  ##     memory: 100Mi
+  ##   limits:
+  ##     cpu: 1000m
+  ##     memory: 1000Mi
+  ##
+  resources: {}
+  ## Controller containers' liveness probe
+  ## @param controller.livenessProbe Set the liveness probe for the Controller container
+  ## e.g:
+  ## livenessProbe:
+  ##   httpGet:
+  ##     path: /readiness
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   periodSeconds: 5
+  ##   failureThreshold: 3
+  ##
+  livenessProbe: {}
+  ## Controller containers' readiness probe
+  ## @param controller.readinessProbe Set the readiness probe for the Controller container
+  ## e.g:
+  ## readinessProbe:
+  ##   httpGet:
+  ##     path: /health
+  ##     port: probes
+  ##     scheme: HTTP
+  ##   periodSeconds: 5
+  ##   failureThreshold: 6
+  ##
+  readinessProbe: {}
+  ## @param controller.affinity Affinity for Controller pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+  ## @param controller.nodeSelector Node labels for Controller pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ##
+  nodeSelector: {}
+  ## @param controller.tolerations Tolerations for Controller pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
+## Knative Serving Webhook
 webhook:
+  ## @param webhook.enabled Enable Webhook container deployment
+  ##
+  enabled: true
+  ## Knative Serving Webhook image
+  ## @param webhook.image.registry Webhook image registry
+  ## @param webhook.image.repository Webhook image repository
+  ## @param webhook.image.tag Webhook image tag
+  ## @param webhook.image.digest Webhook image digest
+  ## @param webhook.image.pullPolicy Webhook image pull policy
+  ## @param webhook.image.pullSecrets Webhook image pull secrets
+  ##
   image:
-    registry: gcr.io/knative-releases
-    repository: knative.dev/serving/cmd/webhook
+    registry: gcr.io
+    repository: knative-releases/knative.dev/serving/cmd/webhook
     tag: ""
     digest: sha256:0fb5a4245aa4737d443658754464cd0a076de959fe14623fb9e9d31318ccce24
     pullPolicy: IfNotPresent
+    ## e.g.
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
     pullSecrets: []
+  ## @param webhook.containerPorts.metrics
+  ## @param webhook.containerPorts.profiling
+  ## @param webhook.containerPorts.https
+  ##
+  containerPorts:
+    metrics: 9090
+    profiling: 8008
+    https: 8443
+  ## @param webhook.serviceAccount.name The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template
+  ##
+  serviceAccount:
+    name: controller
+  ## @param webhook.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## e.g:
+  ## resources:
+  ##   requests:
+  ##     cpu: 100m
+  ##     memory: 100Mi
+  ##   limits:
+  ##     cpu: 500m
+  ##     memory: 500Mi
+  ##
+  resources: {}
+  ## Webhook containers' liveness probe
+  ## @param webhook.livenessProbe Set the liveness probe for the Webhook container
+  ## e.g:
+  ## livenessProbe:
+  ##   periodSeconds: 10
+  ##   httpGet:
+  ##     scheme: HTTPS
+  ##     port: https-webhook
+  ##   failureThreshold: 6
+  ##   initialDelaySeconds: 20
+  ##
+  livenessProbe: {}
+  ## Webhook containers' readiness probe
+  ## @param webhook.readinessProbe Set the readiness probe for the Webhook container
+  ## e.g:
+  ## readinessProbe:
+  ##   periodSeconds: 1
+  ##   httpGet:
+  ##     scheme: HTTPS
+  ##     port: https-webhook
+  ##
+  readinessProbe: {}
+  ## @param webhook.affinity Affinity for Webhook pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+  ## @param webhook.nodeSelector Node labels for Webhook pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ##
+  nodeSelector: {}
+  ## @param webhook.tolerations Tolerations for Webhook pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param webhook.terminationGracePeriodSeconds The period of time in seconds after the webhook container receives a termination signal before the container should be terminated
+  ##
+  terminationGracePeriodSeconds: 300


### PR DESCRIPTION
Values have been updated to match knative-eventing. Includes adding `containerPorts`, `serviceAccount`, `resources`, `livenessProbe`, `livenessProbe`, `affinity`, `nodeSelector`, `tolerations` and `terminationGracePeriodSeconds`.

Packages: knative-serving