### PR TITLE
fix(docs): add recommendation annotations for eventing

### DIFF
--- a/charts/knative-eventing/Chart.yaml
+++ b/charts/knative-eventing/Chart.yaml
@@ -5,6 +5,8 @@
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "true"
+  artifacthub.io/recommendations: |
+     - url: https://artifacthub.io/packages/helm/ahhhh/knative-serving
 apiVersion: v2
 appVersion: 1.16.3
 description: |
@@ -21,4 +23,4 @@ name: knative-eventing
 sources:
   - https://github.com/Ahhhh-man/charts/tree/main/charts/knative-eventing
 type: application
-version: 0.3.5
+version: 0.3.6


### PR DESCRIPTION
Allow recommendations for other charts in the repository within artefacthub.

Packages: knative-eventing